### PR TITLE
fix: do not externalize next alias, such as config and router

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,8 @@ const withCompileNodeModules = (options = {}) => {
             if (isServer && !isServerless) {
                 config.externals = [
                     ...Array.isArray(serverExternals) ? serverExternals : [serverExternals],
+                    // Prevent multiple router provider/context and config modules from being present in the same process, leading to subtle errors.
+                    ...Object.keys(config.resolve.alias),
                     // Ignore native extensions binary files, since they can't be bundled by webpack
                     /\.node$/,
                     // This is needed since Next.js requires the React to be the same instance in every page.

--- a/index.test.js
+++ b/index.test.js
@@ -11,6 +11,11 @@ const webpackOptions = {
 };
 
 const createWebpackConfig = () => ({
+    resolve: {
+        alias: {
+            foo: 'bar',
+        },
+    },
     module: {
         rules: [
             {
@@ -87,8 +92,11 @@ it('should have pre-configured server externals', () => {
         isServer: true,
     });
 
-    const nativeBinary = config.externals && config.externals[0];
-    const react = config.externals && config.externals[1];
+    const alias = config.externals && config.externals[0];
+    const nativeBinary = config.externals && config.externals[1];
+    const react = config.externals && config.externals[2];
+
+    expect(alias).toBe('foo');
 
     expect(nativeBinary).toBeDefined();
     expect(nativeBinary.test('foo.node')).toBeTruthy();
@@ -110,7 +118,7 @@ it('should unshift custom server externals (single)', () => {
         isServer: true,
     });
 
-    expect(config.externals).toHaveLength(3);
+    expect(config.externals).toHaveLength(4);
     expect(config.externals[0]).toBe('foo');
 });
 
@@ -124,7 +132,7 @@ it('should unshift custom server externals (array)', () => {
         isServer: true,
     });
 
-    expect(config.externals).toHaveLength(4);
+    expect(config.externals).toHaveLength(5);
     expect(config.externals[0]).toBe('foo');
     expect(config.externals[1]).toBe('bar');
 });


### PR DESCRIPTION
This fixes issues during development where multiple router provider/context and config modules were present in the same process, leading to subtle errors.