### PR TITLE
fix: compatibility with Next >= v9.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,16 @@ module.exports = withCSS(
 |  ---   |     ---     | ---  |   ---   |
 | test | The Webpack rule test condition | [Rule.test](https://webpack.js.org/configuration/module/#ruletest) | `/\.js$/` |
 | include | The Webpack rule include condition | [Rule.include](https://webpack.js.org/configuration/module/#ruleinclude) | `/[\\/]node_modules[\\/]/` |
-| exclude | The Webpack rule exclude condition | [Rule.exclude](https://webpack.js.org/configuration/module/#ruleexclude) | |
-| serverExternals | Prepend additional externals dependencies besides the built-in**¹** ones. This option is ignored in the client build or when target is serverless | Any [supported types](https://webpack.js.org/configuration/externals/)
+| exclude | Prepend exclusions to the Webpack rule exclude condition besides the built-in**¹** ones | [Rule.exclude](https://webpack.js.org/configuration/module/#ruleexclude) | |
+| serverExternals | Prepend additional externals dependencies besides the built-in**²** ones. This option is ignored in the client build or when target is serverless | Any [supported types](https://webpack.js.org/configuration/externals/)
 
-**¹** Built-in ones are modules related to react, preventing React from being bundled individually in each page which would cause issues such as "React Hooks would throw: Invalid Hook Call Warning".
+**¹** Built-in exclusions are Next.js and Webpack related, such as [`node-libs-browser`](https://www.npmjs.com/package/node-libs-browser) and [`process`](https://www.npmjs.com/package/node-process).
+
+**²** Built-in externals are Next.js related as well as modules associated with React. More specifically, it prevents React from being bundled individually in each page which would cause issues such as "React Hooks would throw: Invalid Hook Call Warning".
 
 ### Custom babel config
 
-If you are using a custom `babel.config.js`, you may need to identify if we are compiling a node module or not:
+If you are using a custom `babel.config.js`, you may identify if we are compiling a node module or not via `api.caller` like so:
 
 ```js
 // babel.config.js
@@ -83,12 +85,6 @@ module.exports = (api) => {
     };
 };
 ```
-
-### External dependencies
-
-We're removing the property `externals` from the `webpack` configuration in order to include external dependencies in the bundle of our applications.
-This ensures all the dependencies are compiled according to our targets.
-More information in [Webpack's documentation](https://webpack.js.org/configuration/externals/).
 
 ## Tests
 

--- a/index.test.js
+++ b/index.test.js
@@ -45,6 +45,9 @@ it('should duplicate the default JS rule', () => {
 
     expect(rule.test.toString()).toBe('/\\.js$/');
     expect(rule.include.toString()).toMatch(/\bnode_modules\b/);
+    expect(rule.exclude.toString()).toMatch(/\bnode-libs-browser\b/);
+    expect(rule.exclude.toString()).toMatch(/\bprocess\b/);
+
     expect(rule.use.options.distDir).toBe('my-project/.next/cache/compile-node-modules-plugin');
     expect(rule.use.options.caller).toEqual({ isNodeModule: true });
 
@@ -60,7 +63,7 @@ it('should throw if the JS rule was not found', () => {
     expect(() => compileNodeModulesPlugin()().webpack(noGoodRuleConfig, webpackOptions)).toThrow(/JS rule/);
 });
 
-it('should allow to override the rule\'s test, include and exclude properties', () => {
+it('should allow to override the rule\'s test & include', () => {
     const options = {
         test: 'my-test',
         include: 'my-include',
@@ -73,7 +76,19 @@ it('should allow to override the rule\'s test, include and exclude properties', 
 
     expect(rule.test).toBe('my-test');
     expect(rule.include).toBe('my-include');
-    expect(rule.exclude).toBe('my-exclude');
+});
+
+it('should unshift rule\'s exclude conditions if any', () => {
+    const options = {
+        exclude: 'my-exclude',
+    };
+
+    const config = compileNodeModulesPlugin(options)().webpack(createWebpackConfig(), webpackOptions);
+
+    const rule = config.module.rules[1];
+
+    expect(rule.exclude.length).toBeGreaterThan(1);
+    expect(rule.exclude[0]).toBe('my-exclude');
 });
 
 it('should call nextConfig webpack if defined', () => {
@@ -106,6 +121,7 @@ it('should unshift custom server externals (single)', () => {
         isServer: true,
     });
 
+    expect(config.externals.length).toBeGreaterThan(1);
     expect(config.externals[0]).toBe('added-external');
 });
 
@@ -119,6 +135,7 @@ it('should unshift custom server externals (array)', () => {
         isServer: true,
     });
 
+    expect(config.externals.length).toBeGreaterThan(2);
     expect(config.externals[0]).toBe('added-external-1');
     expect(config.externals[1]).toBe('added-external-2');
 });


### PR DESCRIPTION
Next.js >= v9.1.5 is now inlining statements through `babel-plugin-transform-define`, see https://github.com/zeit/next.js/blob/d64587e1a3af11411a6c458ae9544950dfba7825/packages/next/build/webpack/loaders/next-babel-loader.js#L185

However, the `process.browser` inlining was causing problems with Webpack builtin `node-libs-browser` (mock) and `node-process`.